### PR TITLE
resizerootfs: make recipe MACHINE_ARCH

### DIFF
--- a/recipes-bsp/bootsetup/resizerootfs.bb
+++ b/recipes-bsp/bootsetup/resizerootfs.bb
@@ -1,6 +1,8 @@
 DESCRIPTION = "Resize Rootfs"
 require conf/license/license-gplv2.inc
 
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
 COMPATIBLE_MACHINE = "osmio4k"
 
 RDEPENDS_${PN} = "e2fsprogs-resize2fs"


### PR DESCRIPTION
This commit will change resizerootfs to MACHINE_ARCH
in order not to conflict with other BSP's using same
solution to resize rootfs.