### PR TITLE
linux: fix building on newer OE

### DIFF
--- a/recipes-kernel/linux/linux-edision_5.5.16.bb
+++ b/recipes-kernel/linux/linux-edision_5.5.16.bb
@@ -18,7 +18,7 @@ SRC_URI[kernel.sha256sum] = "85fb308a8a204e4913e078d50ac94dad05a6aca9cacfe5d6b6f
 SRC_URI[kernelpatch.md5sum] = "b236278e10577cb8d172c71ff84e31f6"
 SRC_URI[kernelpatch.sha256sum] = "1bf802cbc3f16a3bdf1a05a3a089135a31f6d3dd031314a44fa4d4fc06cef662"
 
-FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}* ${KERNEL_IMAGEDEST}/findkerneldevice.py"
+FILES_${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}* ${KERNEL_IMAGEDEST}/findkerneldevice.py"
 
 do_shared_workdir_append() {
 	unset CFLAGS CPPFLAGS CXXFLAGS LDFLAGS

--- a/recipes-kernel/linux/linux-os.inc
+++ b/recipes-kernel/linux/linux-os.inc
@@ -21,7 +21,7 @@ B = "${WORKDIR}/build"
 
 KERNEL_IMAGEDEST = "tmp"
 
-FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
+FILES_${KERNEL_PACKAGE_NAME}-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
 
 pkg_postinst_kernel-image () {
 	if [ -z "$D" ]

--- a/recipes-kernel/linux/linux-os/0002-log2-give-up-on-gcc-constant-optimizations.patch
+++ b/recipes-kernel/linux/linux-os/0002-log2-give-up-on-gcc-constant-optimizations.patch
@@ -1,0 +1,85 @@
+From f6bde93fb7d1b758a6b63abb64385774d841dd79 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Tue, 31 Jul 2018 21:09:02 +0200
+Subject: [PATCH] log2 give up on gcc constant optimizations
+
+
+diff --git a/include/linux/log2.h b/include/linux/log2.h
+index fd7ff3d9..f38fae23 100644
+--- a/include/linux/log2.h
++++ b/include/linux/log2.h
+@@ -15,12 +15,6 @@
+ #include <linux/types.h>
+ #include <linux/bitops.h>
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -85,7 +79,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -148,10 +142,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+diff --git a/tools/include/linux/log2.h b/tools/include/linux/log2.h
+index 41446668..d5677d39 100644
+--- a/tools/include/linux/log2.h
++++ b/tools/include/linux/log2.h
+@@ -12,12 +12,6 @@
+ #ifndef _TOOLS_LINUX_LOG2_H
+ #define _TOOLS_LINUX_LOG2_H
+ 
+-/*
+- * deal with unrepresentable constant logarithms
+- */
+-extern __attribute__((const, noreturn))
+-int ____ilog2_NaN(void);
+-
+ /*
+  * non-constant log of base 2 calculators
+  * - the arch may override these in asm/bitops.h if they can be implemented
+@@ -78,7 +72,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ #define ilog2(n)				\
+ (						\
+ 	__builtin_constant_p(n) ? (		\
+-		(n) < 1 ? ____ilog2_NaN() :	\
++		(n) < 2 ? 0 :			\
+ 		(n) & (1ULL << 63) ? 63 :	\
+ 		(n) & (1ULL << 62) ? 62 :	\
+ 		(n) & (1ULL << 61) ? 61 :	\
+@@ -141,10 +135,7 @@ unsigned long __rounddown_pow_of_two(unsigned long n)
+ 		(n) & (1ULL <<  4) ?  4 :	\
+ 		(n) & (1ULL <<  3) ?  3 :	\
+ 		(n) & (1ULL <<  2) ?  2 :	\
+-		(n) & (1ULL <<  1) ?  1 :	\
+-		(n) & (1ULL <<  0) ?  0 :	\
+-		____ilog2_NaN()			\
+-				   ) :		\
++		1 ) :				\
+ 	(sizeof(n) <= 4) ?			\
+ 	__ilog2_u32(n) :			\
+ 	__ilog2_u64(n)				\
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/linux-os/0003-cp1emu-do-not-use-bools-for-arithmetic.patch
+++ b/recipes-kernel/linux/linux-os/0003-cp1emu-do-not-use-bools-for-arithmetic.patch
@@ -1,0 +1,28 @@
+From 7e2e3315210534e3e98e57a9ef373ef48534c507 Mon Sep 17 00:00:00 2001
+From: Nicker <nickersk@gmail.com>
+Date: Tue, 31 Jul 2018 23:40:25 +0200
+Subject: [PATCH] cp1emu do not use bools for arithmetic
+
+
+diff --git a/arch/mips/math-emu/cp1emu.c b/arch/mips/math-emu/cp1emu.c
+index 36775d20..20ec51ee 100644
+--- a/arch/mips/math-emu/cp1emu.c
++++ b/arch/mips/math-emu/cp1emu.c
+@@ -829,12 +829,12 @@ do {									\
+ } while (0)
+ 
+ #define DIFROMREG(di, x)						\
+-	((di) = get_fpr64(&ctx->fpr[(x) & ~(cop1_64bit(xcp) == 0)], 0))
++	((di) = get_fpr64(&ctx->fpr[(x) & ~(cop1_64bit(xcp) ^ 1)], 0))
+ 
+ #define DITOREG(di, x)							\
+ do {									\
+ 	unsigned fpr, i;						\
+-	fpr = (x) & ~(cop1_64bit(xcp) == 0);				\
++	fpr = (x) & ~(cop1_64bit(xcp) ^ 1);				\
+ 	set_fpr64(&ctx->fpr[fpr], 0, di);				\
+ 	for (i = 1; i < ARRAY_SIZE(ctx->fpr[x].val64); i++)		\
+ 		set_fpr64(&ctx->fpr[fpr], i, 0);			\
+-- 
+2.17.1
+

--- a/recipes-kernel/linux/linux-os_4.8.17.bb
+++ b/recipes-kernel/linux/linux-os_4.8.17.bb
@@ -3,6 +3,8 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=d7810fab7487fb0aad327b76f1be7cd7"
 
 SRC_URI = "http://source.mynonpublic.com/edision/linux-edision-${PV}.tar.xz \
 	file://defconfig \
+	file://0002-log2-give-up-on-gcc-constant-optimizations.patch \
+	file://0003-cp1emu-do-not-use-bools-for-arithmetic.patch \
 	"
 
 COMPATIBLE_MACHINE = "osnino|osninoplus|osninopro"


### PR DESCRIPTION
This commit allows packaging of the kernel to work properly on newer OE.