### PR TITLE
wireguard: build as module on 4k models

### DIFF
--- a/recipes-kernel/linux/linux-edision/osmini4k/defconfig
+++ b/recipes-kernel/linux/linux-edision/osmini4k/defconfig
@@ -1690,7 +1690,7 @@ CONFIG_MII=y
 CONFIG_NET_CORE=y
 # CONFIG_BONDING is not set
 # CONFIG_DUMMY is not set
-# CONFIG_WIREGUARD is not set
+CONFIG_WIREGUARD=m
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
 # CONFIG_NET_TEAM is not set

--- a/recipes-kernel/linux/linux-edision/osmio4k/defconfig
+++ b/recipes-kernel/linux/linux-edision/osmio4k/defconfig
@@ -1690,7 +1690,7 @@ CONFIG_MII=y
 CONFIG_NET_CORE=y
 # CONFIG_BONDING is not set
 # CONFIG_DUMMY is not set
-# CONFIG_WIREGUARD is not set
+CONFIG_WIREGUARD=m
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
 # CONFIG_NET_TEAM is not set

--- a/recipes-kernel/linux/linux-edision/osmio4kplus/defconfig
+++ b/recipes-kernel/linux/linux-edision/osmio4kplus/defconfig
@@ -1690,7 +1690,7 @@ CONFIG_MII=y
 CONFIG_NET_CORE=y
 # CONFIG_BONDING is not set
 # CONFIG_DUMMY is not set
-# CONFIG_WIREGUARD is not set
+CONFIG_WIREGUARD=m
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
 # CONFIG_NET_TEAM is not set


### PR DESCRIPTION
Wireguard is part of kernel since 5.6. Build the required module.